### PR TITLE
Boot files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,14 @@
 # Use golang 1.11 as build stage
 FROM golang:1.11 as build
 
+# Copy Isard iPXE
+COPY . /go/src/github.com/isard-vdi/isard-ipxe
+
 # Move to the correct directory
-COPY . /go/src/github.com/isard-vdi/isard-ipxe/
 WORKDIR /go/src/github.com/isard-vdi/isard-ipxe
 
 # Compile the binary
 RUN make build
-
-# Create the user
-RUN adduser --disabled-password --gecos '' app
 
 #
 # Base stage
@@ -27,21 +26,11 @@ RUN adduser --disabled-password --gecos '' app
 # Use alpine 3.8 as base
 FROM alpine:3.8
 
-# Copy the /etc/passwd (which contains the user 'app') from the build stage
-COPY --from=build /etc/passwd /etc/passwd
-
 # Copy the compiled binary from the build stage
 COPY --from=build /go/src/github.com/isard-vdi/isard-ipxe/isard-ipxe /app/isard-ipxe
 
-# Create the data directory and set the correct permissions
-RUN mkdir /data
-RUN chown app /data
-
 # Move to the correct directory
 WORKDIR /data
-
-# Use the 'app' user
-USER app
 
 # Expose the volume
 VOLUME [ "/data" ]

--- a/cmd/isard-ipxe/main.go
+++ b/cmd/isard-ipxe/main.go
@@ -26,6 +26,8 @@ func generateMux() *http.ServeMux {
 	mux.HandleFunc("/pxe/boot/auth", handlers.AuthHandler)
 	mux.HandleFunc("/pxe/boot/list", handlers.VMListHandler)
 	mux.HandleFunc("/pxe/boot/start", handlers.StartHandler)
+	mux.HandleFunc("/pxe/boot/vmlinuz", handlers.VmlinuzHandler)
+	mux.HandleFunc("/pxe/boot/initrd", handlers.InitrdHandler)
 
 	return mux
 }

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -138,3 +138,13 @@ func StartHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("error writting the boot menu: %v", err)
 	}
 }
+
+// VmlinuzHandler is the handler that serves the vmlinuz file for the boot
+func VmlinuzHandler(w http.ResponseWriter, r *http.Request) {
+	http.ServeFile(w, r, "/data/vmlinuz")
+}
+
+// InitrdHandler is the handler that serves the initrd file for the boot
+func InitrdHandler(w http.ResponseWriter, r *http.Request) {
+	http.ServeFile(w, r, "/data/initrd")
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -141,10 +141,10 @@ func StartHandler(w http.ResponseWriter, r *http.Request) {
 
 // VmlinuzHandler is the handler that serves the vmlinuz file for the boot
 func VmlinuzHandler(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "/data/vmlinuz")
+	http.ServeFile(w, r, "images/vmlinuz"+r.FormValue("arch"))
 }
 
 // InitrdHandler is the handler that serves the initrd file for the boot
 func InitrdHandler(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "/data/initrd")
+	http.ServeFile(w, r, "images/initrd"+r.FormValue("arch"))
 }

--- a/pkg/menus/assets/boot.ipxe
+++ b/pkg/menus/assets/boot.ipxe
@@ -1,4 +1,4 @@
 #!ipxe
-kernel {{.BaseURL}}/pxe/vmlinuz tkn={{.Token}} id={{.VMID}} initrd={{.BaseURL}}/pxe/initrd
-initrd {{.BaseURL}}/pxe/initrd
+kernel {{.BaseURL}}/pxe/boot/vmlinuz tkn={{.Token}} id={{.VMID}} initrd={{.BaseURL}}/pxe/boot/initrd
+initrd {{.BaseURL}}/pxe/boot/initrd
 boot

--- a/pkg/menus/assets/boot.ipxe
+++ b/pkg/menus/assets/boot.ipxe
@@ -1,4 +1,4 @@
 #!ipxe
-kernel {{.BaseURL}}/pxe/boot/vmlinuz tkn={{.Token}} id={{.VMID}} initrd={{.BaseURL}}/pxe/boot/initrd
-initrd {{.BaseURL}}/pxe/boot/initrd
+kernel {{.BaseURL}}/pxe/boot/vmlinuz?arch=${buildarch:uristring} tkn={{.Token}} id={{.VMID}} initrd={{.BaseURL}}/pxe/boot/initrd?arch=${buildarch:uristring}
+initrd {{.BaseURL}}/pxe/boot/initrd?arch=${buildarch:uristring}
 boot


### PR DESCRIPTION
Now Isard iPXE can serve the files required for booting (initrd and vmlinuz [each one depending on the CPU architecture of the client])